### PR TITLE
fix: [Syaiful] typo naming jwt secret key on .env and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ DB_TEST_PORT=
 DB_TEST_DIALECT=
 
 # jwt config
-JWT_Secret_Key=
+JWT_SECRET_KEY=
 
 # cloudinary credential
 CLOUDINARY_URL=

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -1,7 +1,7 @@
 const { User } = require('../models')
 const bcrypt = require('bcrypt')
 const jwt = require('jsonwebtoken');
-const secretKey =  process.env.JWT_SECRET || "rahasia";
+const secretKey =  process.env.JWT_SECRET_KEY;
 
 const userRegister = async (req, res) => {
     const { name, password, email, is_admin, address } = req.body;


### PR DESCRIPTION
change `JWT_SECRET` and `JWT_Secret_Key` to `JWT_SECRET_KEY`